### PR TITLE
Fix case where only part of the sub-package path is given

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.2 (unreleased)
+================
+
+- Fixed bug that caused e.g. ``-P sub`` to not match ``package.sub.other``. [#1]
+
 0.1 (2020-01-09)
 ================
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
   parameters:
     envs:
     # Code style
-    - linux: style
+    - linux: codestyle
     # Standard tests
     - linux: py36-test
     - linux: py37-test

--- a/pytest_filter_subpackage/plugin.py
+++ b/pytest_filter_subpackage/plugin.py
@@ -53,9 +53,6 @@ def pytest_ignore_collect(path, config):
 
     path = os.path.sep.join(path[i+1:])
 
-    # Now convert the remainder of the path to subpackage name, excluding
-    # the very first part of the path (which will be the main package name
-    # or e.g. docs)
     subpackage = '.'.join(path.split(os.path.sep))
 
     # Find selected sub-packages

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,5 +33,6 @@ def testpackage(testdir):
         pkg.join(sub).join('tests').join(f'test_{sub}.py') \
            .write(TEST_TEMPLATE.format(sub=sub))
     docs = testdir.mkdir('docs')
+    docs.join('index.rst').write('')
     for sub in ('a', 'c'):
         docs.mkdir(sub).join('index.rst').write(DOCS_TEMPLATE.format(sub=sub))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,10 @@ def testpackage(testdir):
         pkg.join(sub).mkdir('tests').join('__init__.py').write('')
         pkg.join(sub).join('tests').join(f'test_{sub}.py') \
            .write(TEST_TEMPLATE.format(sub=sub))
+    pkg.join('c').mkdir('d').join('__init__.py').write('')
+    pkg.join('c').join('d').mkdir('tests').join('__init__.py').write('')
+    pkg.join('c').join('d').join('tests').join('test_d.py') \
+       .write(TEST_TEMPLATE.format(sub='d'))
     docs = testdir.mkdir('docs')
     docs.join('index.rst').write('')
     for sub in ('a', 'c'):

--- a/tests/test_filter_subpackage.py
+++ b/tests/test_filter_subpackage.py
@@ -4,7 +4,7 @@ pytest_plugins = ['pytester']
 def test_default(testdir, testpackage):
     # Make sure all code tests are picked up by default
     reprec = testdir.inline_run()
-    reprec.assertoutcome(passed=4, failed=2)
+    reprec.assertoutcome(passed=5, failed=3)
 
 
 def test_with_rst(testdir, testpackage):
@@ -14,7 +14,7 @@ def test_with_rst(testdir, testpackage):
     doctest_plus = enabled
     """)
     reprec = testdir.inline_run('--doctest-rst')
-    reprec.assertoutcome(passed=7, failed=2)
+    reprec.assertoutcome(passed=8, failed=3)
 
 
 def test_flag_single_subpackage(testdir, testpackage):
@@ -47,3 +47,9 @@ def test_flag_multiple_subpackage_with_rst(testdir, testpackage):
     """)
     reprec = testdir.inline_run('-P a,b', '--doctest-rst')
     reprec.assertoutcome(passed=4, failed=1)
+
+
+def test_flag_single_subpackage_partial(testdir, testpackage):
+    # Check that -P c will collect tests in c.d
+    reprec = testdir.inline_run('-P c')
+    reprec.assertoutcome(passed=2, failed=2)

--- a/tests/test_filter_subpackage.py
+++ b/tests/test_filter_subpackage.py
@@ -14,7 +14,7 @@ def test_with_rst(testdir, testpackage):
     doctest_plus = enabled
     """)
     reprec = testdir.inline_run('--doctest-rst')
-    reprec.assertoutcome(passed=6, failed=2)
+    reprec.assertoutcome(passed=7, failed=2)
 
 
 def test_flag_single_subpackage(testdir, testpackage):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38}-test
-    style
+    codestyle
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -18,7 +18,7 @@ commands =
     pip freeze
     test: pytest {toxinidir}/tests {posargs}
 
-[testenv:style]
+[testenv:codestyle]
 skip_install = true
 description = check code style
 deps = flake8


### PR DESCRIPTION
For example previously ``-P visualization`` did not match ``astropy.visualization.wcsaxes``