### PR TITLE
Unpin tox<4 on Windows py37

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,13 +22,7 @@ jobs:
     - macos: py38-test
     - macos: py39-test
     - macos: py310-test
+    - windows: py37-test
     - windows: py38-test
     - windows: py39-test
     - windows: py310-test
-
-# Until https://github.com/OpenAstronomy/azure-pipelines-templates/issues/86 is fixed, then move this back to the previous job
-- template: run-tox-env.yml@OpenAstronomy
-  parameters:
-    toxverspec: <4
-    envs:
-    - windows: py37-test


### PR DESCRIPTION
Was looking into https://github.com/OpenAstronomy/azure-pipelines-templates/issues/86 but the log has expired.