### PR TITLE
Raise internal error for nonexistent subpackages

### DIFF
--- a/pytest_filter_subpackage/plugin.py
+++ b/pytest_filter_subpackage/plugin.py
@@ -64,7 +64,6 @@ if PYTEST_GE_8_0:
 
         # Find selected sub-packages
         selected = config.getvalue('package').strip().split(',')
-
         # Finally, we check if this is one of the specified ones
         for subpackage_target in selected:
             for i, target in enumerate(subpackage_target.split('.')):
@@ -75,6 +74,11 @@ if PYTEST_GE_8_0:
                 return None
 
         return True
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_collection_finish(session):
+        if len(session.items) == 0:
+            raise ValueError("Please provide a valid subpackage name with the -P option.")
 
 else:
 

--- a/tests/test_filter_subpackage.py
+++ b/tests/test_filter_subpackage.py
@@ -59,3 +59,7 @@ def test_flag_single_subsubpackage(testdir, testpackage):
     # Check that -P c.d will not collect tests in c.
     reprec = testdir.inline_run('-P c.d')
     reprec.assertoutcome(passed=1, failed=1)
+
+def test_nonexistent_subpackage(testdir, testpackage):
+    reprec = testdir.runpytest('-P f')
+    assert reprec.ret == 3


### PR DESCRIPTION
A hacky fix for https://github.com/astropy/pytest-filter-subpackage/issues/9, not sure if this the best way. Maybe it's okay to just keep it as it is? pytest seems to consider zero collected tests also as a special case, https://docs.pytest.org/en/stable/reference/exit-codes.html

Fixes #9