### PR TITLE
MNT: Drop Python 3.8 and 3.9, and add support for Python 3.13

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  # v5.2.0
       with:
-        python-version: 3.8
+        python-version: '3.10'
 
     - name: Install python-build and twine
       run: python -m pip install pip build "twine>=3.3" -U

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,29 +19,29 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-test-pytestoldest
+            python-version: '3.10'
+            toxenv: py310-test-pytestoldest
           - os: windows-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest50
+            python-version: '3.10'
+            toxenv: py310-test-pytest50
           - os: macos-12
-            python-version: 3.8
-            toxenv: py38-test-pytest51
+            python-version: '3.10'
+            toxenv: py310-test-pytest51
           - os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest52
+            python-version: '3.10'
+            toxenv: py310-test-pytest52
           - os: windows-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest53
+            python-version: '3.10'
+            toxenv: py310-test-pytest53
           - os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest60
+            python-version: '3.10'
+            toxenv: py310-test-pytest60
           - os: ubuntu-latest
-            python-version: 3.9
-            toxenv: py39-test-pytest61
+            python-version: '3.10'
+            toxenv: py310-test-pytest61
           - os: ubuntu-latest
-            python-version: 3.9
-            toxenv: py39-test-pytest62
+            python-version: '3.10'
+            toxenv: py310-test-pytest62
           - os: ubuntu-latest
             python-version: '3.10'
             toxenv: py310-test-pytest70
@@ -70,11 +70,11 @@ jobs:
             python-version: '3.11'
             toxenv: py311-test-pytestdev
           - os: windows-latest
-            python-version: '3.11'
-            toxenv: py311-test-pytestdev
-          - os: ubuntu-latest
             python-version: '3.12'
             toxenv: py312-test-pytestdev
+          - os: ubuntu-latest
+            python-version: '3.13-dev'
+            toxenv: py313-test-pytestdev
 
     steps:
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,37 +21,16 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
             toxenv: py310-test-pytestoldest
-          - os: windows-latest
-            python-version: '3.10'
-            toxenv: py310-test-pytest50
           - os: macos-12
             python-version: '3.10'
-            toxenv: py310-test-pytest51
-          - os: ubuntu-latest
-            python-version: '3.10'
-            toxenv: py310-test-pytest52
-          - os: windows-latest
-            python-version: '3.10'
-            toxenv: py310-test-pytest53
-          - os: ubuntu-latest
-            python-version: '3.10'
-            toxenv: py310-test-pytest60
-          - os: ubuntu-latest
-            python-version: '3.10'
-            toxenv: py310-test-pytest61
-          - os: ubuntu-latest
-            python-version: '3.10'
-            toxenv: py310-test-pytest62
-          - os: ubuntu-latest
-            python-version: '3.10'
             toxenv: py310-test-pytest70
-          - os: ubuntu-latest
+          - os: windows-latest
             python-version: '3.10'
             toxenv: py310-test-pytest71
           - os: windows-latest
             python-version: '3.11'
             toxenv: py311-test-pytest72
-          - os: ubuntu-latest
+          - os: macos-12
             python-version: '3.11'
             toxenv: py311-test-pytest73
           - os: ubuntu-latest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.3.0 (unreleased)
 ==================
 
+- Dropped Python 3.8 and 3.9 support. Added support for Python 3.13. [#21]
+
 0.2.0 (2024-03-04)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.3.0 (unreleased)
 ==================
 
-- Dropped Python 3.8 and 3.9 support. Added support for Python 3.13. [#21]
+- Dropped Python 3.8 and 3.9 support. Added support for Python 3.13.
+  Minimum supported pytest is now 6.2. [#21]
 
 0.2.0 (2024-03-04)
 ==================

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2019, Astropy Developers
+Copyright (c) 2019-2024, Astropy Developers
 
 All rights reserved.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ zip_safe = False
 packages = find:
 python_requires = >=3.10
 install_requires =
-	pytest>=4.6
+	pytest>=6.2
 	packaging
 
 [options.entry_points]
@@ -42,7 +42,7 @@ test =
     pytest-cov
 
 [tool:pytest]
-minversion = 4.6
+minversion = 6.2
 testpaths = tests pytest_filter_subpackage
 xfail_strict = true
 filterwarnings =

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,11 +11,10 @@ classifiers =
 	Operating System :: OS Independent
 	Programming Language :: Python
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.8
-	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
 	Programming Language :: Python :: 3.12
+	Programming Language :: Python :: 3.13
 	Topic :: Software Development :: Testing
 	Topic :: Utilities
 license = BSD
@@ -27,7 +26,7 @@ keywords = pytest, py.test
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.10
 install_requires =
 	pytest>=4.6
 	packaging

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ isolated_build = true
 changedir = .tmp/{envname}
 description = run tests with pytest
 deps =
-    pytestoldest: pytest==6.2.0
+    pytestoldest: pytest==6.2.*
     pytest70: pytest==7.0.*
     pytest71: pytest==7.1.*
     pytest72: pytest==7.2.*

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-test
+    py{310,311,312,313}-test
     codestyle
 requires =
     setuptools >= 30.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,14 +11,7 @@ isolated_build = true
 changedir = .tmp/{envname}
 description = run tests with pytest
 deps =
-    pytestoldest: pytest==4.6.0
-    pytest50: pytest==5.0.*
-    pytest51: pytest==5.1.*
-    pytest52: pytest==5.2.*
-    pytest53: pytest==5.3.*
-    pytest60: pytest==6.0.*
-    pytest61: pytest==6.1.*
-    pytest62: pytest==6.2.*
+    pytestoldest: pytest==6.2.0
     pytest70: pytest==7.0.*
     pytest71: pytest==7.1.*
     pytest72: pytest==7.2.*


### PR DESCRIPTION
Fix #20 (also have to bump pytest minversion to 6.2)

Close #3 (because the report is for Python 3.8 that we are dropping)