### PR TITLE
TST: Replace macos-13 with macos-14

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,7 +21,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
             toxenv: py310-test-pytestoldest
-          - os: macos-14
+          - os: macos-latest
             python-version: '3.10'
             toxenv: py310-test-pytest70
           - os: windows-latest
@@ -30,7 +30,7 @@ jobs:
           - os: windows-latest
             python-version: '3.11'
             toxenv: py311-test-pytest72
-          - os: macos-14
+          - os: macos-latest
             python-version: '3.11'
             toxenv: py311-test-pytest73
           - os: ubuntu-latest

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,7 +21,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
             toxenv: py310-test-pytestoldest
-          - os: macos-13
+          - os: macos-14
             python-version: '3.10'
             toxenv: py310-test-pytest70
           - os: windows-latest
@@ -30,7 +30,7 @@ jobs:
           - os: windows-latest
             python-version: '3.11'
             toxenv: py311-test-pytest72
-          - os: macos-13
+          - os: macos-14
             python-version: '3.11'
             toxenv: py311-test-pytest73
           - os: ubuntu-latest


### PR DESCRIPTION
https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down